### PR TITLE
Bug: Use (XOB, YOB) for 132/232 obs instead of (XDR, YDR)

### DIFF
--- a/create_syn_ob_jobs.py
+++ b/create_syn_ob_jobs.py
@@ -133,6 +133,7 @@ for bufr_t in bufr_times:
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('source ../activate_python_env.sh\n')
             fptr.write('python uas_sites.py %s/%s \n\n' % (param['paths']['osse_code'], in_yaml))
 
@@ -144,6 +145,7 @@ for bufr_t in bufr_times:
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python create_uas_csv.py %s \\\n' % t_str)
             fptr.write('                         %s \\\n' % fake_csv_bogus_fname)
             fptr.write('                         %s/%s \n\n' % (param['paths']['osse_code'], in_yaml))
@@ -157,6 +159,7 @@ for bufr_t in bufr_times:
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python create_synthetic_obs.py %s \\\n' % param['paths']['model'])
             if param['create_csv']['use']:
                 fptr.write('                               %s \\\n' % param['paths']['syn_bogus_csv'])
@@ -181,6 +184,7 @@ for bufr_t in bufr_times:
                                                        param['paths']['syn_err_csv'], 
                                                        t_str, tag))
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python add_obs_errors.py %s \\\n' % t_str)
             fptr.write('                         %s \\\n' % tag)
             fptr.write('                         %s/%s \n' % (param['paths']['osse_code'], in_yaml))
@@ -197,6 +201,7 @@ for bufr_t in bufr_times:
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python combine_bufr_csv.py %s \\\n' % in1_csv_comb_fname)
             fptr.write('                           %s \\\n' % in2_csv_comb_fname)
             fptr.write('                           %s \n\n' % fake_csv_comb_fname)
@@ -210,6 +215,7 @@ for bufr_t in bufr_times:
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python select_obtypes.py %s \\\n' % convert_csv_fname)
             fptr.write('                         %s \\\n' % fake_csv_select_fname)
             fptr.write('                         %s/%s \n\n' % (param['paths']['osse_code'], in_yaml))
@@ -258,6 +264,7 @@ for bufr_t in bufr_times:
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
             fptr.write('mkdir %s/%s\n' % (param['paths']['plots'], t_str))
             fptr.write('cd %s/plotting\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             if param['create_csv']['use']:
                 fptr.write('python plot_uas_NR_diffs.py %s \\\n' % tag)
                 fptr.write('                            %s \\\n' % t_str)

--- a/main/create_synthetic_obs.py
+++ b/main/create_synthetic_obs.py
@@ -503,9 +503,10 @@ for s in obs_3d:
 # adjustment
 if use_raob_drift:
     if 'ADPUPA' in ob_idx.keys():
-        out_df.loc[ob_idx['ADPUPA'], 'XOB'] = out_df.loc[ob_idx['ADPUPA'], 'XDR']
-        out_df.loc[ob_idx['ADPUPA'], 'YOB'] = out_df.loc[ob_idx['ADPUPA'], 'YDR']
-        out_df.loc[ob_idx['ADPUPA'], 'DHR'] = out_df.loc[ob_idx['ADPUPA'], 'HRDR']
+        drift_idx = np.logical_and(out_df['subset'] == 'ADPUPA', ~np.isnan(out_df['XDR']))
+        out_df.loc[drift_idx, 'XOB'] = out_df.loc[drift_idx, 'XDR']
+        out_df.loc[drift_idx, 'YOB'] = out_df.loc[drift_idx, 'YDR']
+        out_df.loc[drift_idx, 'DHR'] = out_df.loc[drift_idx, 'HRDR']
 
 # Create array to save v1d arrays (vertical coordinate) and surface height (sfch)
 v1d = np.ones([model_nz, len(out_df)]) * 1e9

--- a/synthetic_ob_creator_param.yml
+++ b/synthetic_ob_creator_param.yml
@@ -22,7 +22,7 @@ paths:
   syn_bufr: '/work2/noaa/wrfruc/murdzek/nature_run_winter/synthetic_obs_bufr'
   real_red_bufr: '/work2/noaa/wrfruc/murdzek/nature_run_winter/real_red_obs_bufr'
   model: '/work2/noaa/wrfruc/murdzek/nature_run_winter/UPP'
-  log: '/work2/noaa/wrfruc/murdzek/nature_run_winter/synthetic_obs_csv/logs_test'
+  log: '/work2/noaa/wrfruc/murdzek/nature_run_winter/synthetic_obs_csv/logs'
   plots: '/work2/noaa/wrfruc/murdzek/nature_run_winter/synthetic_obs_csv/plots'
   osse_code: '/work2/noaa/wrfruc/murdzek/src/osse_ob_creator'
   bufr_code: '/work2/noaa/wrfruc/murdzek/src/prepbufr_decoder'
@@ -37,7 +37,7 @@ shared:
     - 'rap_e'
     - 'rap_p' 
   uas_grid_file: '/work2/noaa/wrfruc/murdzek/src/osse_ob_creator/uas_site_locs_150km.txt'
-  log_str: 'test'
+  log_str: 'perfect_conv'
 
 jobs:
   max: 25
@@ -54,7 +54,7 @@ jobs:
 #-----------
 
 convert_bufr: 
-  use: False
+  use: True
 
 create_uas_grid: 
   use: False
@@ -78,7 +78,7 @@ create_csv:
   uas_offset: 0.
 
 interpolator: 
-  use: False
+  use: True
   obs_2d:
     - 'ADPSFC'
     - 'SFCSHP'
@@ -89,7 +89,7 @@ interpolator:
     - 'AIRCAR'
     - 'AIRCFT'
   copy_winds: False
-  interp_z_aircft: null
+  interp_z_aircft: False
   height_opt: null
   use_raob_drift: True
   coastline_correct: False
@@ -98,8 +98,8 @@ interpolator:
   debug: 0
 
 obs_errors: 
-  use: False
-  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
+  use: True
+  errtable: '/work2/noaa/wrfruc/murdzek/src/osse_ob_creator/utils/errtable.tmp'
   autocor_POB_obs:
     - 120 
     - 220
@@ -132,7 +132,7 @@ combine_csv:
   csv2_dir: '/work2/noaa/wrfruc/murdzek/nature_run_winter/synthetic_obs_csv/perfect_uas'
 
 select_obs:
-  use: True
+  use: False
   obtypes:
     - 120
     - 126
@@ -171,13 +171,13 @@ select_obs:
     - 295
 
 convert_syn_csv: 
-  use: False
+  use: True
 
 convert_real_red_csv: 
-  use: False
+  use: True
 
 plots:
-  use: False
+  use: True
   diff_2d:
     bufr_dir: 'syn_perf_csv'
     subsets:


### PR DESCRIPTION
XDR and YDR are set to NaN for 132/232 obs (dropsondes), so these obs should use (XOB, YOB) rather than (XDR, YDR) when creating synthetic obs