### PR TITLE
Add ability to limit one prepBUFR file based on conditions in a second prepBUFR file

### DIFF
--- a/README_inputs.md
+++ b/README_inputs.md
@@ -107,22 +107,6 @@ Interpolates Nature Run output in space and time to observation locations specif
 - **add_liq_mix**: Option to interpolate liquid water mixing ratio (cloud + rain mixing ratio) to the observations. This field is saved to a new CSV column labeled "liqmix".
 - **debug**: Option to add additional output for debugging (0 = none, 1 = some, 2 = a lot).
 
-### limit_uas
-
-Limits synthetic UAS flights based on local meteorology (e.g., high winds). Uses `main/limit_uas_flights.py`.
-
-- **in_csv_dir**: Which path from the `paths` section to pull observation CSVs from.
-- **drop_col**: List of columns to drop after limiting UAS flights. This is useful for removing columns in the BUFR CSV files that are only included for limiting UAS flights (e.g., liqmix).
-- **verbose**: Verbosity. Higher integers will print more output
-- **limits**: Parameters for limiting UAS flights. Includes 3 levels:
-    1. Observation type used to determine whether a limit is exceeded
-    2. Method for limiting UAS flight ("wind", "icing_RH", or "icing_LIQMR"; options can also be found in `main/limit_uas_flights.py`)
-    3. "lim_kw" and "remove_kw": Keyword arguments passed to either the method that determines whether a meteorological limit is exceeded or the method that actually removes the observations that exceed the meteorological limits, respectively. Keyword arguments can be found in `pyDA_utils/limit_prepbufr.py`.
-- **plot_timeseries**: Parameters for plotting timeseries of UAS observations before and after meteorological limits are applied.
-    - **plot_vars**: Variable to plot, along with a single value to plot as a dashed, horizontal line (useful for plotting the meteorological limit for that variable).
-    - **n_sid**: Number of unique SIDs to plot. The program will automatically choose the SIDs that had the largest reductions owing to the meteorological limits.
-    - **obtype**: Observation type to pull the SIDs for "n_sid" from.
-
 ### obs_errors 
 
 Add observation errors to observations within an observation CSV file. Uses `main/add_obs_errors.py`.
@@ -135,6 +119,23 @@ Add observation errors to observations within an observation CSV file. Uses `mai
 - **verbose**: Option to turn on verbose output (useful for debugging).
 - **dewpt_check**: Option to check whether the reported dewpoint (TDO) is consistent with the reported temperature (TOB) and specific humidity (QOB).
 - **plot_diff_hist**: Option to make plots of the observations before and after adding teh random errors.
+
+### limit_uas
+
+Limits synthetic UAS flights based on local meteorology (e.g., high winds). Uses `main/limit_uas_flights.py`.
+
+- **in_csv_dir**: Which path from the `paths` section to pull observation CSVs from. Observations are removed from these CSV files.
+- **csv_ref_dir**: Which path from the `paths` section to pull observation CSVs from. These CSV files are used to determine which observations to remove from the CSV files in `in_csv_dir`.
+- **drop_col**: List of columns to drop after limiting UAS flights. This is useful for removing columns in the BUFR CSV files that are only included for limiting UAS flights (e.g., liqmix).
+- **verbose**: Verbosity. Higher integers will print more output
+- **limits**: Parameters for limiting UAS flights. Includes 3 levels:
+    1. Observation type used to determine whether a limit is exceeded
+    2. Method for limiting UAS flight ("wind", "icing_RH", or "icing_LIQMR"; options can also be found in `main/limit_uas_flights.py`)
+    3. "lim_kw" and "remove_kw": Keyword arguments passed to either the method that determines whether a meteorological limit is exceeded or the method that actually removes the observations that exceed the meteorological limits, respectively. Keyword arguments can be found in `pyDA_utils/limit_prepbufr.py`.
+- **plot_timeseries**: Parameters for plotting timeseries of UAS observations before and after meteorological limits are applied.
+    - **plot_vars**: Variable to plot, along with a single value to plot as a dashed, horizontal line (useful for plotting the meteorological limit for that variable).
+    - **n_sid**: Number of unique SIDs to plot. The program will automatically choose the SIDs that had the largest reductions owing to the meteorological limits.
+    - **obtype**: Observation type to pull the SIDs for "n_sid" from.
 
 ### combine_csv
 

--- a/create_syn_ob_jobs.py
+++ b/create_syn_ob_jobs.py
@@ -317,6 +317,28 @@ for bufr_t in bufr_times:
             convert_csv_fname = fake_csv_perf_fname        
             if param['jobs']['use_rocoto']: close_file(fptr)
 
+        if param['obs_errors']['use']:
+            if param['jobs']['use_rocoto']: fptr, batch_fname = init_file(param, t_str, tag, task='obs_errors')
+            fptr.write('# Add observation errors\n')
+            fptr.write('echo ""\n')
+            fptr.write('echo "=============================================================="\n')
+            fptr.write('echo "Add observation errors"\n')
+            fptr.write('echo ""\n')
+            fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
+            fptr.write('cp %s %s/%s.%s.input.csv\n' % (fake_csv_perf_fname,
+                                                       param['paths']['syn_err_csv'], 
+                                                       t_str, tag))
+            fptr.write('cd %s/main\n' % param['paths']['osse_code'])
+            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
+            fptr.write('python add_obs_errors.py %s \\\n' % t_str)
+            fptr.write('                         %s \\\n' % tag)
+            fptr.write('                         %s/%s \n' % (param['paths']['osse_code'], in_yaml))
+            fptr.write('mv %s/%s.%s.output.csv %s\n\n' % (param['paths']['syn_err_csv'], 
+                                                          t_str, tag, 
+                                                          fake_csv_err_fname))
+            convert_csv_fname = fake_csv_err_fname        
+            if param['jobs']['use_rocoto']: close_file(fptr)
+
         if param['limit_uas']['use']:
             if param['jobs']['use_rocoto']: fptr, batch_fname = init_file(param, t_str, tag, task='limit_uas')
             fptr.write('# Limiting UAS flights\n')
@@ -343,28 +365,6 @@ for bufr_t in bufr_times:
                 fptr.write('                                           %s \\\n' % tag)
                 fptr.write('                                           %s/%s \n\n' % (param['paths']['osse_code'], in_yaml))
             convert_csv_fname = fake_csv_limit_uas_fname        
-            if param['jobs']['use_rocoto']: close_file(fptr)
-
-        if param['obs_errors']['use']:
-            if param['jobs']['use_rocoto']: fptr, batch_fname = init_file(param, t_str, tag, task='obs_errors')
-            fptr.write('# Add observation errors\n')
-            fptr.write('echo ""\n')
-            fptr.write('echo "=============================================================="\n')
-            fptr.write('echo "Add observation errors"\n')
-            fptr.write('echo ""\n')
-            fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
-            fptr.write('cp %s %s/%s.%s.input.csv\n' % (fake_csv_perf_fname,
-                                                       param['paths']['syn_err_csv'], 
-                                                       t_str, tag))
-            fptr.write('cd %s/main\n' % param['paths']['osse_code'])
-            fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
-            fptr.write('python add_obs_errors.py %s \\\n' % t_str)
-            fptr.write('                         %s \\\n' % tag)
-            fptr.write('                         %s/%s \n' % (param['paths']['osse_code'], in_yaml))
-            fptr.write('mv %s/%s.%s.output.csv %s\n\n' % (param['paths']['syn_err_csv'], 
-                                                          t_str, tag, 
-                                                          fake_csv_err_fname))
-            convert_csv_fname = fake_csv_err_fname        
             if param['jobs']['use_rocoto']: close_file(fptr)
 
         if param['combine_csv']['use']:

--- a/plotting/plot_full_limited_uas_timeseries.py
+++ b/plotting/plot_full_limited_uas_timeseries.py
@@ -26,8 +26,8 @@ import pyDA_utils.bufr as bufr
 # Input Parameters
 #---------------------------------------------------------------------------------------------------
 
-# BUFR file with full UAS profile
-bufr_file_full = '/work2/noaa/wrfruc/murdzek/nature_run_spring/obs/uas_obs_35km_wspd20/limit_uas_csv/202204292300.rap.input.csv'
+# BUFR file with reference UAS profile
+bufr_file_ref = '/work2/noaa/wrfruc/murdzek/nature_run_spring/obs/uas_obs_35km_wspd20/limit_uas_csv/202204292300.rap.input.csv'
 
 # BUFR file with limited UAS profile
 bufr_file_limit = '/work2/noaa/wrfruc/murdzek/nature_run_spring/obs/uas_obs_35km_wspd20/limit_uas_csv/202204292300.rap.fake.prepbufr.csv'
@@ -45,7 +45,7 @@ obtype = 136
 verbose = 1
 
 # Output file name (include %s placeholder for SID)
-out_fname = './uas_full_limit_timeseries_%s.png'
+out_fname = './uas_ref_limit_timeseries_%s.png'
 
 # Use passed arguments, if they exist
 if len(sys.argv) > 1:
@@ -53,14 +53,13 @@ if len(sys.argv) > 1:
     tag = sys.argv[2]
     with open(sys.argv[3], 'r') as fptr:
         param = yaml.safe_load(fptr)
-    bufr_file_full = '%s/%s.%s.input.csv' % (param['paths']['syn_limit_uas_csv'],
-                                             t_str, tag)
     bufr_file_limit = '%s/%s.%s.fake.prepbufr.csv' % (param['paths']['syn_limit_uas_csv'],
                                                       t_str, tag)
+    bufr_file_ref = f"{param['paths'][param['limit_uas']['csv_ref_dir']]}/{t_str}.{tag}.fake.prepbufr.csv"
     plot_vars = param['limit_uas']['plot_timeseries']['plot_vars']
     n_sid = param['limit_uas']['plot_timeseries']['n_sid']
     obtype = param['limit_uas']['plot_timeseries']['obtype']
-    out_fname = '%s/%s' % (param['paths']['plots'], t_str) + '/uas_full_limit_timeseries_%s.png'
+    out_fname = '%s/%s' % (param['paths']['plots'], t_str) + '/uas_ref_limit_timeseries_%s.png'
 
 
 #---------------------------------------------------------------------------------------------------
@@ -69,7 +68,7 @@ if len(sys.argv) > 1:
 
 # Read in BUFR CSV files
 bufr_df = {}
-for fname, key in zip([bufr_file_full, bufr_file_limit], ['full', 'limit']):
+for fname, key in zip([bufr_file_limit, bufr_file_ref], ['limit', 'ref']):
     if verbose > 0: print(f"reading {fname}")
     bufr_df[key] = bufr.bufrCSV(fname).df
 
@@ -89,14 +88,14 @@ for key in bufr_df.keys():
 
 # Remove SIDs with no obs after accounting for limits
 keep_idx = []
-for i, sid in enumerate(sid_cts['full']['SID']):
+for i, sid in enumerate(sid_cts['ref']['SID']):
     if sid in sid_cts['limit']['SID']:
         keep_idx.append(i)
-sid_cts['full']['SID'] = sid_cts['full']['SID'][keep_idx]
-sid_cts['full']['n'] = sid_cts['full']['n'][keep_idx]
+sid_cts['ref']['SID'] = sid_cts['ref']['SID'][keep_idx]
+sid_cts['ref']['n'] = sid_cts['ref']['n'][keep_idx]
 
 # Determine SIDs to plot by finding which SIDs had the largest reductions owing to the flight limits
-plot_sid = sid_cts['full']['SID'][np.argsort(sid_cts['full']['n'] - sid_cts['limit']['n'])[::-1][:n_sid]]
+plot_sid = sid_cts['ref']['SID'][np.argsort(sid_cts['ref']['n'] - sid_cts['limit']['n'])[::-1][:n_sid]]
 
 # Create plots
 for sid in plot_sid:
@@ -110,9 +109,9 @@ for sid in plot_sid:
 
     # Loop over each variable
     for v, ax in zip(plot_vars.keys(), axes):
-        bufr_df['full'].loc[bufr_df['full']['SID'] == sid].plot(x='DHR', y=v, ax=ax, kind='line',
-                                                                legend=False, ylabel=v,
-                                                                style=['-'], lw=1.5, c='b')
+        bufr_df['ref'].loc[bufr_df['ref']['SID'] == sid].plot(x='DHR', y=v, ax=ax, kind='line',
+                                                              legend=False, ylabel=v,
+                                                              style=['-'], lw=1.5, c='b')
         if v in bufr_df['limit'].columns:
             bufr_df['limit'].loc[bufr_df['limit']['SID'] == sid].plot(x='DHR', y=v, ax=ax, 
                                                                       kind='line', legend=False, 
@@ -120,14 +119,14 @@ for sid in plot_sid:
 
         if v == 'liqmix':
             ymin = -0.1 * plot_vars[v]
-            ymax = 1.05 * max([plot_vars[v], np.amax(bufr_df['full'].loc[bufr_df['full']['SID'] == sid, v])])
+            ymax = 1.05 * max([plot_vars[v], np.amax(bufr_df['ref'].loc[bufr_df['ref']['SID'] == sid, v])])
             ax.set_ylim([ymin, ymax])
             ax.ticklabel_format(axis='y', style='sci', scilimits=(0,0))
 
         ax.axhline(plot_vars[v], ls='--', c='k')
         ax.grid()
 
-    plt.suptitle(f'Full (blue) and Limited (red) Timeseries for {sid}', size=14)
+    plt.suptitle(f'Reference (blue) and Limited (red) Timeseries for {sid}', size=14)
     plt.savefig(out_fname % sid)
     plt.close()
 

--- a/synthetic_ob_creator_param.yml
+++ b/synthetic_ob_creator_param.yml
@@ -103,9 +103,25 @@ interpolator:
   add_liq_mix: True
   debug: 0
 
+obs_errors: 
+  use: True
+  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtables/2nd_iter_assim_only/include_uas/errtable.7day'
+  autocor_POB_obs:
+    - 126 
+  autocor_DHR_obs: 
+    - 136
+    - 236
+  autocor_ZOB_partition_DHR_obs: 
+    - 126
+  auto_reg_parm: 0.5
+  verbose: False
+  dewpt_check: False
+  plot_diff_hist: True
+
 limit_uas:
   use: True
   in_csv_dir: 'syn_perf_csv'
+  csv_ref_dir: 'syn_perf_csv'
   drop_col:
     - 'liqmix'
   verbose: 2
@@ -124,21 +140,6 @@ limit_uas:
       WSPD: 20
     n_sid: 10
     obtype: 136
-
-obs_errors: 
-  use: True
-  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtables/2nd_iter_assim_only/include_uas/errtable.7day'
-  autocor_POB_obs:
-    - 126 
-  autocor_DHR_obs: 
-    - 136
-    - 236
-  autocor_ZOB_partition_DHR_obs: 
-    - 126
-  auto_reg_parm: 0.5
-  verbose: False
-  dewpt_check: False
-  plot_diff_hist: True
 
 combine_csv:
   use: True

--- a/tests/linear_interp_test.yml
+++ b/tests/linear_interp_test.yml
@@ -104,9 +104,39 @@ interpolator:
   add_liq_mix: False
   debug: 2
 
+obs_errors: 
+  use: False
+  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
+  autocor_POB_obs:
+    - 120 
+    - 220
+  autocor_DHR_obs: 
+    - 130
+    - 131
+    - 133
+    - 134
+    - 135
+    - 230
+    - 231
+    - 233
+    - 234
+    - 235
+  autocor_ZOB_partition_DHR_obs: 
+    - 126
+    - 223
+    - 224
+    - 227
+    - 228
+    - 229
+  auto_reg_parm: 0.5
+  verbose: False
+  dewpt_check: False
+  plot_diff_hist: False
+
 limit_uas:
   use: False
   in_csv_dir: 'syn_perf_csv'
+  csv_ref_dif: 'syn_perf_csv'
   drop_col:
     - 
   verbose: 2
@@ -136,35 +166,6 @@ limit_uas:
       RHOB: 90
     n_sid: 5
     obtype: 136
-
-obs_errors: 
-  use: False
-  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
-  autocor_POB_obs:
-    - 120 
-    - 220
-  autocor_DHR_obs: 
-    - 130
-    - 131
-    - 133
-    - 134
-    - 135
-    - 230
-    - 231
-    - 233
-    - 234
-    - 235
-  autocor_ZOB_partition_DHR_obs: 
-    - 126
-    - 223
-    - 224
-    - 227
-    - 228
-    - 229
-  auto_reg_parm: 0.5
-  verbose: False
-  dewpt_check: False
-  plot_diff_hist: False
 
 combine_csv:
   use: False

--- a/tests/select_obs_test.yml
+++ b/tests/select_obs_test.yml
@@ -104,9 +104,39 @@ interpolator:
   add_liq_mix: False
   debug: 2
 
+obs_errors: 
+  use: False
+  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
+  autocor_POB_obs:
+    - 120 
+    - 220
+  autocor_DHR_obs: 
+    - 130
+    - 131
+    - 133
+    - 134
+    - 135
+    - 230
+    - 231
+    - 233
+    - 234
+    - 235
+  autocor_ZOB_partition_DHR_obs: 
+    - 126
+    - 223
+    - 224
+    - 227
+    - 228
+    - 229
+  auto_reg_parm: 0.5
+  verbose: False
+  dewpt_check: False
+  plot_diff_hist: False
+
 limit_uas:
   use: False
   in_csv_dir: 'syn_perf_csv'
+  csv_ref_dir: 'syn_perf_csv'
   drop_col:
     - 
   verbose: 2
@@ -136,35 +166,6 @@ limit_uas:
       RHOB: 90
     n_sid: 5
     obtype: 136
-
-obs_errors: 
-  use: False
-  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
-  autocor_POB_obs:
-    - 120 
-    - 220
-  autocor_DHR_obs: 
-    - 130
-    - 131
-    - 133
-    - 134
-    - 135
-    - 230
-    - 231
-    - 233
-    - 234
-    - 235
-  autocor_ZOB_partition_DHR_obs: 
-    - 126
-    - 223
-    - 224
-    - 227
-    - 228
-    - 229
-  auto_reg_parm: 0.5
-  verbose: False
-  dewpt_check: False
-  plot_diff_hist: False
 
 combine_csv:
   use: False

--- a/tests/uas_test.yml
+++ b/tests/uas_test.yml
@@ -103,9 +103,39 @@ interpolator:
   add_liq_mix: True
   debug: 2
 
+obs_errors: 
+  use: False
+  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
+  autocor_POB_obs:
+    - 120 
+    - 220
+  autocor_DHR_obs: 
+    - 130
+    - 131
+    - 133
+    - 134
+    - 135
+    - 230
+    - 231
+    - 233
+    - 234
+    - 235
+  autocor_ZOB_partition_DHR_obs: 
+    - 126
+    - 223
+    - 224
+    - 227
+    - 228
+    - 229
+  auto_reg_parm: 0.5
+  verbose: False
+  dewpt_check: False
+  plot_diff_hist: False
+
 limit_uas:
   use: True
   in_csv_dir: 'syn_perf_csv'
+  csv_ref_dir: 'syn_perf_csv'
   drop_col:
     - 'liqmix'
   verbose: 2
@@ -135,35 +165,6 @@ limit_uas:
       liqmix: 0.5
     n_sid: 2
     obtype: 136
-
-obs_errors: 
-  use: False
-  errtable: '/work2/noaa/wrfruc/murdzek/real_obs/errtable.rrfs'
-  autocor_POB_obs:
-    - 120 
-    - 220
-  autocor_DHR_obs: 
-    - 130
-    - 131
-    - 133
-    - 134
-    - 135
-    - 230
-    - 231
-    - 233
-    - 234
-    - 235
-  autocor_ZOB_partition_DHR_obs: 
-    - 126
-    - 223
-    - 224
-    - 227
-    - 228
-    - 229
-  auto_reg_parm: 0.5
-  verbose: False
-  dewpt_check: False
-  plot_diff_hist: False
 
 combine_csv:
   use: False


### PR DESCRIPTION
Updated code expands the `limit_uas` task so that meteorological conditions from one prepBUFR CSV file can be used to limit UAS flights in a second prepBUFR CSV file. The goal is to use this feature to limit UAS flights that include added errors using a set of "perfect" UAS observations. If the same two files are used for all meteorological limit configurations (e.g., 20 m/s, 30 m/s), then the errors added to the UAS observations will also be the same, which is desirable for controlled experiments for testing the impact of adding meteorological limits.

Tests: All tests in `tests/run_test.sh` pass on Hercules.