### PR TITLE
Speed up limit_uas task and use links for input files

### DIFF
--- a/create_syn_ob_jobs.py
+++ b/create_syn_ob_jobs.py
@@ -325,9 +325,9 @@ for bufr_t in bufr_times:
             fptr.write('echo "Add observation errors"\n')
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
-            fptr.write('cp %s %s/%s.%s.input.csv\n' % (fake_csv_perf_fname,
-                                                       param['paths']['syn_err_csv'], 
-                                                       t_str, tag))
+            fptr.write('ln -sf %s %s/%s.%s.input.csv\n' % (fake_csv_perf_fname,
+                                                           param['paths']['syn_err_csv'], 
+                                                           t_str, tag))
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
             fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python add_obs_errors.py %s \\\n' % t_str)
@@ -347,9 +347,9 @@ for bufr_t in bufr_times:
             fptr.write('echo "Limiting UAS flights"\n')
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
-            fptr.write('cp %s %s/%s.%s.input.csv\n' % (in_csv_limit_uas_fname,
-                                                       param['paths']['syn_limit_uas_csv'], 
-                                                       t_str, tag))
+            fptr.write('ln -sf %s %s/%s.%s.input.csv\n' % (in_csv_limit_uas_fname,
+                                                           param['paths']['syn_limit_uas_csv'], 
+                                                           t_str, tag))
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
             fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python limit_uas_flights.py %s \\\n' % t_str)
@@ -421,9 +421,9 @@ for bufr_t in bufr_times:
             fptr.write('echo "Create superobs"\n')
             fptr.write('echo ""\n')
             fptr.write('source %s/activate_python_env.sh\n' % param['paths']['osse_code'])
-            fptr.write('cp %s %s/%s.%s.input.csv\n' % (in_csv_superob_fname,
-                                                       param['paths']['syn_superob_csv'], 
-                                                       t_str, tag))
+            fptr.write('ln -sf %s %s/%s.%s.input.csv\n' % (in_csv_superob_fname,
+                                                           param['paths']['syn_superob_csv'], 
+                                                           t_str, tag))
             fptr.write('cd %s/main\n' % param['paths']['osse_code'])
             fptr.write('echo "Using osse_ob_creator version `git describe`"\n')
             fptr.write('python create_superobs.py %s \\\n' % t_str)

--- a/main/limit_uas_flights.py
+++ b/main/limit_uas_flights.py
@@ -55,7 +55,12 @@ if verbose > 1:
 # Read in input prepBUFR file
 bufr_obj = bufr.bufrCSV(in_csv_fname)
 bufr_obj_ref = bufr.bufrCSV(csv_ref_fname)
-keep_col = bufr_obj.df.columns.values
+
+# Check that bufr_obj and bufr_obj_ref have the same obs
+check_col = ['SID', 'TYP', 'DHR', 'XOB', 'YOB']
+for c in check_col:
+    if ~np.all(bufr_obj.df[c].values == bufr_obj_ref.df[c].values):
+        raise ValueError('bufr_obj and bufr_obj_ref contain different observations')
 
 # Check how many obs we are starting with
 if verbose > 0:
@@ -92,10 +97,12 @@ for typ in limits_param.keys():
 
         # Remove BUFR obs that exceed the limit
         if verbose > 1: print('  removing obs   ', dt.datetime.now())
-        bufr_obj.df = lp.remove_obs_after_lim(bufr_obj.df, bufr_obj_ref.df, typ, 
-                                              **limits_param[typ][lim_type]['remove_kw'])
-        bufr_obj_ref.df = lp.remove_obs_after_lim(bufr_obj_ref.df, bufr_obj_ref.df, typ, 
-                                                  **limits_param[typ][lim_type]['remove_kw'])
+        drop_idx = lp.remove_obs_after_lim(bufr_obj_ref.df, typ, 
+                                           **limits_param[typ][lim_type]['remove_kw'])
+        bufr_obj_ref.df.drop(idx_drop, inplace=True)
+        bufr_obj_ref.df.reset_index(inplace=True, drop=True)
+        bufr_obj.df.drop(idx_drop, inplace=True)
+        bufr_obj.df.reset_index(inplace=True, drop=True)
 
 # Print how many obs were removed
 if verbose > 0: 
@@ -108,9 +115,6 @@ if verbose > 0:
 
 # Remove intermediate fields and save results
 if verbose > 1: print('removing intermediate columns', dt.datetime.now())
-for c in bufr_obj.df:
-    if c not in keep_col:
-        drop_col.append(c)
 bufr_obj.df.drop(drop_col, axis=1, inplace=True)
 bufr.df_to_csv(bufr_obj.df, out_csv_fname)
 

--- a/main/limit_uas_flights.py
+++ b/main/limit_uas_flights.py
@@ -97,7 +97,7 @@ for typ in limits_param.keys():
 
         # Remove BUFR obs that exceed the limit
         if verbose > 1: print('  removing obs   ', dt.datetime.now())
-        drop_idx = lp.remove_obs_after_lim(bufr_obj_ref.df, typ, 
+        idx_drop = lp.remove_obs_after_lim(bufr_obj_ref.df, typ, 
                                            **limits_param[typ][lim_type]['remove_kw'])
         bufr_obj_ref.df.drop(idx_drop, inplace=True)
         bufr_obj_ref.df.reset_index(inplace=True, drop=True)


### PR DESCRIPTION
PR includes two main changes:

- Changes to how `pyDA_utils.limit_prepbufr.remove_obs_after_lim()` is called from `main/limit_uas_flights.py` so that the function only needs to be called once. This should speed up the limit_uas task, though preliminary tests with only a few obs (300 km spacing between sites) indicate that the runtime might only decrease by ~10% for `main/limit_uas_flights.py`
- Use links instead of copying when creating input CSV files. This should reduce the storage footprint of the entire program, especially when using high-resolution UAS observations.

Tests: All tests in `tests/run_test.sh` pass on Hercules.